### PR TITLE
Ensure Garamond fonts apply to canvas

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -1,5 +1,9 @@
-@import url("https://fonts.googleapis.com/css2?family=Fira+Code&family=Inter:wght@400;500;600;700&display=swap");
-@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap");
+/*
+ * Import the primary font families used throughout the app. Fira Code is
+ * retained for monospace content. EB Garamond provides the main serif stack
+ * for a clean, journal-like aesthetic.
+ */
+@import url("https://fonts.googleapis.com/css2?family=Fira+Code&family=EB+Garamond:wght@400;500;600;700&display=swap");
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
@@ -41,8 +45,12 @@ a {
 
 @layer base {
   :root {
-    --background: 0 0% 100%;
-    --foreground: 0 0% 3.9%;
+    /*
+     * Use a near-white background and very dark text for a minimal, print-like
+     * appearance. Subtle grayscale accents keep the interface unobtrusive.
+     */
+    --background: 0 0% 97%;
+    --foreground: 0 0% 7%;
     --card: 0 0% 100%;
     --card-foreground: 0 0% 3.9%;
     --popover: 0 0% 100%;
@@ -57,8 +65,8 @@ a {
     --accent-foreground: 0 0% 9%;
     --destructive: 0 84.2% 60.2%;
     --destructive-foreground: 0 0% 98%;
-    --border: 0 0% 89.8%;
-    --input: 0 0% 89.8%;
+    --border: 0 0% 90%;
+    --input: 0 0% 90%;
     --ring: 0 0% 3.9%;
     --chart-1: 12 76% 61%;
     --chart-2: 173 58% 39%;
@@ -94,18 +102,8 @@ a {
     --chart-5: 340 75% 55%;
   }
   html {
-    font-family:
-      "Inter",
-      -apple-system,
-      BlinkMacSystemFont,
-      "Segoe UI",
-      Roboto,
-      Helvetica,
-      Arial,
-      sans-serif,
-      "Apple Color Emoji",
-      "Segoe UI Emoji",
-      "Segoe UI Symbol";
+    /* Default serif stack emphasizing Garamond for body text. */
+    font-family: "EB Garamond", serif;
   }
 }
 
@@ -153,6 +151,8 @@ a {
 
 .custom-blocknote-theme {
   --bn-colors-editor-text: #3f3f3f;
+  /* Override BlockNote's default font to match the Garamond theme. */
+  --bn-font-family: "EB Garamond", serif;
 }
 
 .custom-blocknote-theme a {

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,11 +1,13 @@
 import type { Metadata } from "next";
 import "./globals.css";
-import { Inter } from "next/font/google";
+import { EB_Garamond } from "next/font/google";
 import { cn } from "@/lib/utils";
 import { NuqsAdapter } from "nuqs/adapters/next/app";
 
-const inter = Inter({
+// Load EB Garamond via the optimized Next.js font loader.
+const garamond = EB_Garamond({
   subsets: ["latin"],
+  weight: ["400", "500", "600", "700"],
 });
 
 export const metadata: Metadata = {
@@ -20,7 +22,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" className="h-screen">
-      <body className={cn("min-h-full", inter.className)}>
+      <body className={cn("min-h-full", garamond.className)}>
         <NuqsAdapter>{children}</NuqsAdapter>
       </body>
     </html>

--- a/apps/web/src/components/artifacts/TextRenderer.tsx
+++ b/apps/web/src/components/artifacts/TextRenderer.tsx
@@ -1,6 +1,5 @@
 import { Dispatch, SetStateAction, useEffect, useRef, useState } from "react";
 import { ArtifactMarkdownV3 } from "@opencanvas/shared/types";
-import "@blocknote/core/fonts/inter.css";
 import {
   getDefaultReactSlashMenuItems,
   SuggestionMenuController,

--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -106,11 +106,15 @@ const config: Config = {
   				'5': 'hsl(var(--chart-5))'
   			}
   		},
-  		fontFamily: {
-  			mono: [
-  				'`"Fira Code"`',
-  				'`ui-monospace`',
-  				'`SFMono-Regular`',
+                fontFamily: {
+                        garamond: [
+                                'EB Garamond',
+                                'serif'
+                        ],
+                        mono: [
+                                '`"Fira Code"`',
+                                '`ui-monospace`',
+                                '`SFMono-Regular`',
   				'`Menlo`',
   				'`Monaco`',
   				'`Consolas`',
@@ -118,20 +122,22 @@ const config: Config = {
   				'`"Courier New"`',
   				'`monospace`'
   			],
-  			sans: [
-  				'Inter',
-  				'-apple-system',
-  				'BlinkMacSystemFont',
-  				'Segoe UI',
-  				'Roboto',
-  				'Helvetica',
-  				'Arial',
-  				'sans-serif',
-  				'Apple Color Emoji',
-  				'Segoe UI Emoji',
-  				'Segoe UI Symbol'
-  			]
-  		},
+                        sans: [
+                                'EB Garamond',
+                                'serif',
+                                'Inter',
+                                '-apple-system',
+                                'BlinkMacSystemFont',
+                                'Segoe UI',
+                                'Roboto',
+                                'Helvetica',
+                                'Arial',
+                                'sans-serif',
+                                'Apple Color Emoji',
+                                'Segoe UI Emoji',
+                                'Segoe UI Symbol'
+                        ]
+                },
   		letterSpacing: {
   			tighter: '-0.04em'
   		}


### PR DESCRIPTION
## Summary
- set BlockNote font variables and remove Inter font import
- prioritize Garamond in Tailwind's sans stack

## Testing
- `yarn format`
- `yarn lint` *(with warnings)*
- `yarn workspace @opencanvas/web eval` *(failed to find test files)*

------
https://chatgpt.com/codex/tasks/task_e_683fe7bdc7a48326a76d1d2c3b520206