### PR TITLE
Fix BlockNote font style

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -153,6 +153,18 @@ a {
   --bn-colors-editor-text: #3f3f3f;
   /* Override BlockNote's default font to match the Garamond theme. */
   --bn-font-family: "EB Garamond", serif;
+  /* Ensure the editor inherits the Garamond stack. */
+  font-family: var(--bn-font-family) !important;
+}
+
+/*
+ * BlockNote scopes some rules to internal elements such as
+ * `.bn-editor` and `.ProseMirror`. Reinforce the font-family
+ * there to avoid fallback to the default sans-serif stack.
+ */
+.custom-blocknote-theme .bn-editor,
+.custom-blocknote-theme .bn-editor .ProseMirror {
+  font-family: var(--bn-font-family) !important;
 }
 
 .custom-blocknote-theme a {


### PR DESCRIPTION
## Summary
- enforce Garamond font in BlockNote via CSS overrides

## Testing
- `yarn lint` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ff5b47f4c8326a3ebd7f7599604a9